### PR TITLE
Update Docker build to use entrypoint script and pyproject installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,19 +21,20 @@ RUN apt-get update && apt-get install -y \
     curl \
     && rm -rf /var/lib/apt/lists/*
 
-# 复制依赖文件
-COPY requirements.txt .
+# 复制依赖文件并安装 Python 依赖
+COPY pyproject.toml ./
+COPY README.md ./
+COPY src ./src
 
-# 安装 Python 依赖
 RUN pip install --no-cache-dir --upgrade pip -i https://pypi.tuna.tsinghua.edu.cn/simple && \
-    pip install --no-cache-dir -r requirements.txt -i https://pypi.tuna.tsinghua.edu.cn/simple
+    pip install --no-cache-dir . -i https://pypi.tuna.tsinghua.edu.cn/simple
 
 # 复制项目文件
 COPY . .
 
 # 复制并设置启动脚本权限
-COPY scripts/docker-entrypoint.sh /docker-entrypoint.sh
-RUN chmod +x /docker-entrypoint.sh
+COPY scripts/docker-entrypoint.sh /scripts/docker-entrypoint.sh
+RUN chmod +x /scripts/docker-entrypoint.sh
 
 # 创建必要的目录
 RUN mkdir -p /app/logs /app/static /app/migrations
@@ -49,4 +50,4 @@ HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 \
     CMD curl -f http://localhost:8000/docs || exit 1
 
 # 启动命令
-CMD ["/docker-entrypoint.sh"]
+CMD ["/scripts/docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -267,6 +267,18 @@ uv run uvicorn src:app --reload --host 0.0.0.0 --port 8000
 uv run uvicorn src:app --host 0.0.0.0 --port 8000 --workers 4
 ```
 
+### 🐳 使用 Docker 运行项目
+
+```bash
+# 构建镜像（在项目根目录执行）
+docker build -t fastapi-template .
+
+# 启动容器并映射端口，可选加载环境变量
+docker run --rm -p 8000:8000 --env-file .env fastapi-template
+```
+
+镜像启动后即可访问 http://localhost:8000/docs 验证服务是否正常，或使用 `curl http://localhost:8000/api/v1/base/health` 进行健康检查。
+
 ### 5. 访问服务
 
 - **🌐 官网文档**: http://fastapi.infyai.cn/

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+set -e
+
+exec uvicorn src:app --host 0.0.0.0 --port 8000


### PR DESCRIPTION
## Summary
- add a `docker-entrypoint.sh` script that boots uvicorn with the packaged FastAPI app
- refactor the Dockerfile to install dependencies from `pyproject.toml` before copying the full source and wire up the new entrypoint path
- document a quick Docker build/run example in the README so users can verify the container image

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d1e76410488321aa4851cd05b82ee1