### PR TITLE
fix: ensure pytest-asyncio plugin loads under strict config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,7 +130,7 @@ disable = ["C0103", "R0903", "W0613"]
 
 [tool.pytest.ini_options]
 minversion = "7.0"
-addopts = "-ra -q --strict-markers --strict-config"
+addopts = "-ra -q --strict-markers --strict-config -p pytest_asyncio"
 testpaths = ["tests"]
 python_files = ["test_*.py"]
 python_classes = ["Test*"]


### PR DESCRIPTION
## Summary
- explicitly load the pytest-asyncio plugin via addopts so the asyncio_mode setting remains valid under strict-config

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ecf671daf8832191f9634c389decff